### PR TITLE
Live services/ad 227108

### DIFF
--- a/NCS.DSS.Outcomes.Tests/FunctionTests/PatchOutcomesHttpTriggerTests.cs
+++ b/NCS.DSS.Outcomes.Tests/FunctionTests/PatchOutcomesHttpTriggerTests.cs
@@ -149,7 +149,7 @@ namespace NCS.DSS.Outcomes.Tests.FunctionTests
         [Test]
         public async Task PatchOutcomesHttpTrigger_ReturnsStatusCodeBadRequest_WhenOutcomePatchCantBePatched()
         {
-            _patchOutcomesHttpTriggerService.GetOutcomesForCustomerAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>()).Returns(Task.FromResult(_outcomeString).Result);
+            _patchOutcomesHttpTriggerService.GetOutcomesForCustomerAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>()).Returns(Task.FromResult(_outcomeString).Result);
 
             _patchOutcomesHttpTriggerService.PatchResource(Arg.Any<string>(), Arg.Any<Models.OutcomesPatch>()).Returns((string)null);
 
@@ -204,7 +204,7 @@ namespace NCS.DSS.Outcomes.Tests.FunctionTests
                 .Returns(false);
 
             _patchOutcomesHttpTriggerService
-                .GetOutcomesForCustomerAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>())
+                .GetOutcomesForCustomerAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>())
                 .Returns(Task.FromResult<string>(null).Result);
 
             // Act
@@ -222,7 +222,7 @@ namespace NCS.DSS.Outcomes.Tests.FunctionTests
                 .Returns(false);
 
             _patchOutcomesHttpTriggerService
-                .GetOutcomesForCustomerAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>())
+                .GetOutcomesForCustomerAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>())
                 .Returns(Task.FromResult<string>(null).Result);
 
             // Act
@@ -237,7 +237,7 @@ namespace NCS.DSS.Outcomes.Tests.FunctionTests
         public async Task PatchOutcomesHttpTrigger_ReturnsStatusCodeNotFound_WhenOutcomesDoesNotExist()
         {
             _patchOutcomesHttpTriggerService
-                .GetOutcomesForCustomerAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>())
+                .GetOutcomesForCustomerAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>())
                 .Returns(Task.FromResult<string>(null).Result);
 
             // Act
@@ -251,7 +251,7 @@ namespace NCS.DSS.Outcomes.Tests.FunctionTests
         public async Task PatchOutcomesHttpTrigger_ReturnsStatusCodeBadRequest_WhenUnableToUpdateOutcomesRecord()
         {
             _patchOutcomesHttpTriggerService
-                .GetOutcomesForCustomerAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>())
+                .GetOutcomesForCustomerAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>())
                 .Returns(Task.FromResult(_outcomeString).Result);
 
             _patchOutcomesHttpTriggerService.UpdateCosmosAsync(Arg.Any<string>(), Arg.Any<Guid>())
@@ -267,7 +267,7 @@ namespace NCS.DSS.Outcomes.Tests.FunctionTests
         public async Task PatchOutcomesHttpTrigger_ReturnsStatusCodeBadRequest_WhenRequestIsNotValid()
         {
             _patchOutcomesHttpTriggerService
-                .GetOutcomesForCustomerAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>())
+                .GetOutcomesForCustomerAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>())
                 .Returns(Task.FromResult(_outcomeString).Result);
 
             _patchOutcomesHttpTriggerService.UpdateCosmosAsync(Arg.Any<string>(), Arg.Any<Guid>())
@@ -283,7 +283,7 @@ namespace NCS.DSS.Outcomes.Tests.FunctionTests
         public async Task PatchOutcomesHttpTrigger_ReturnsStatusCodeOK_WhenRequestIsValid()
         {
             _patchOutcomesHttpTriggerService
-                .GetOutcomesForCustomerAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>())
+                .GetOutcomesForCustomerAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>())
                 .Returns(Task.FromResult(_outcomeString).Result);
 
             _patchOutcomesHttpTriggerService.UpdateCosmosAsync(Arg.Any<string>(), Arg.Any<Guid>())

--- a/NCS.DSS.Outcomes.Tests/ServicesTests/GetOutcomesByIdHttpTriggerServiceTests.cs
+++ b/NCS.DSS.Outcomes.Tests/ServicesTests/GetOutcomesByIdHttpTriggerServiceTests.cs
@@ -31,7 +31,7 @@ namespace NCS.DSS.Outcomes.Tests.ServicesTests
         public async Task GetOutcomesByIdHttpTriggerServiceTests_GetOutcomesForCustomerAsyncc_ReturnsNullWhenResourceCannotBeFound()
         {
             // Arrange
-            _cosmosDbProvider.Setup(x => x.GetOutcomeForCustomerAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>())).Returns(Task.FromResult<Models.Outcomes>(null));
+            _cosmosDbProvider.Setup(x => x.GetOutcomeForCustomerAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>())).Returns(Task.FromResult<Models.Outcomes>(null));
 
             // Act
             var result = await _outcomeHttpTriggerService.GetOutcomesForCustomerAsync(_customerId, _interactionId, _actionPlanId, _outcomeId);
@@ -44,7 +44,7 @@ namespace NCS.DSS.Outcomes.Tests.ServicesTests
         public async Task GetOutcomesByIdHttpTriggerServiceTests_GetOutcomesForCustomerAsync_ReturnsResource()
         {
             // Arrange
-            _cosmosDbProvider.Setup(x => x.GetOutcomeForCustomerAsync(_customerId, _interactionId, _actionPlanId, _outcomeId)).Returns(Task.FromResult(new Models.Outcomes()));
+            _cosmosDbProvider.Setup(x => x.GetOutcomeForCustomerAsync(_customerId, _actionPlanId, _outcomeId)).Returns(Task.FromResult(new Models.Outcomes()));
 
             // Act
             var result = await _outcomeHttpTriggerService.GetOutcomesForCustomerAsync(_customerId, _interactionId, _actionPlanId, _outcomeId);

--- a/NCS.DSS.Outcomes.Tests/ServicesTests/PatchOutcomesHttpTriggerServiceTests.cs
+++ b/NCS.DSS.Outcomes.Tests/ServicesTests/PatchOutcomesHttpTriggerServiceTests.cs
@@ -151,10 +151,10 @@ namespace NCS.DSS.Outcomes.Tests.ServicesTests
         public async Task PatchOutcomesHttpTriggerServiceTests_GetActionPlanForCustomerAsync_ReturnsNullWhenResourceHasNotBeenFound()
         {
             // Arrange
-            _cosmosDbProvider.Setup(x => x.GetOutcomesForCustomerAsyncToUpdateAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>())).Returns(Task.FromResult<string>(null));
+            _cosmosDbProvider.Setup(x => x.GetOutcomesForCustomerAsyncToUpdateAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>())).Returns(Task.FromResult<string>(null));
 
             // Act
-            var result = await _outcomePatchHttpTriggerService.GetOutcomesForCustomerAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>());
+            var result = await _outcomePatchHttpTriggerService.GetOutcomesForCustomerAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>());
 
             // Assert
             Assert.That(result, Is.Null);
@@ -165,10 +165,10 @@ namespace NCS.DSS.Outcomes.Tests.ServicesTests
         {
             var outcomePatch = new Models.OutcomesPatch { OutcomeEffectiveDate = DateTime.MaxValue };
             var json = JsonConvert.SerializeObject(outcomePatch);
-            _cosmosDbProvider.Setup(x => x.GetOutcomesForCustomerAsyncToUpdateAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>())).Returns(Task.FromResult(json));
+            _cosmosDbProvider.Setup(x => x.GetOutcomesForCustomerAsyncToUpdateAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>())).Returns(Task.FromResult(json));
 
             // Act
-            var result = await _outcomePatchHttpTriggerService.GetOutcomesForCustomerAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>());
+            var result = await _outcomePatchHttpTriggerService.GetOutcomesForCustomerAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid>());
 
             // Assert
             Assert.That(result, Is.InstanceOf<string>());

--- a/NCS.DSS.Outcomes/Cosmos/Provider/CosmosDBProvider.cs
+++ b/NCS.DSS.Outcomes/Cosmos/Provider/CosmosDBProvider.cs
@@ -252,9 +252,9 @@ namespace NCS.DSS.Outcomes.Cosmos.Provider
             }
         }
 
-        public async Task<Models.Outcomes> GetOutcomeForCustomerAsync(Guid customerId, Guid interactionsId, Guid actionPlanId, Guid outcomeId)
+        public async Task<Models.Outcomes> GetOutcomeForCustomerAsync(Guid customerId, Guid actionPlanId, Guid outcomeId)
         {
-            _logger.LogInformation("Attempting to retrieve Outcome for a Customer. Customer ID: {CustomerId} Interaction ID: {InteractionId} ActionPlan ID: {ActionPlanId} OutcomeId ID: {OutcomeId}", customerId, interactionsId, actionPlanId, outcomeId);
+            _logger.LogInformation("Attempting to retrieve Outcome for a Customer. Customer ID: {CustomerId} ActionPlan ID: {ActionPlanId} OutcomeId ID: {OutcomeId}", customerId, actionPlanId, outcomeId);
 
             try
             {
@@ -279,14 +279,16 @@ namespace NCS.DSS.Outcomes.Cosmos.Provider
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error retrieving Outcome for a Customer. Customer ID: {CustomerId} Interaction ID: {InteractionId} ActionPlan ID: {ActionPlanId} OutcomeId ID: {OutcomeId}", customerId, interactionsId, actionPlanId, outcomeId);
+                _logger.LogError(ex, "Error retrieving Outcome for a Customer. Customer ID: {CustomerId} ActionPlan ID: {ActionPlanId} OutcomeId ID: {OutcomeId}", customerId, actionPlanId, outcomeId);
                 throw;
             }
         }
 
-        public async Task<string> GetOutcomesForCustomerAsyncToUpdateAsync(Guid customerId, Guid interactionsId, Guid actionPlanId, Guid outcomeId)
+        public async Task<string> GetOutcomesForCustomerAsyncToUpdateAsync(Guid customerId, Guid actionPlanId, Guid outcomeId)
         {
-            var outcome = await GetOutcomeForCustomerAsync(customerId, interactionsId, actionPlanId, outcomeId);
+            var outcome = await GetOutcomeForCustomerAsync(customerId, actionPlanId, outcomeId);
+            if (outcome == null)
+                return null;
 
             return JsonConvert.SerializeObject(outcome);
         }

--- a/NCS.DSS.Outcomes/Cosmos/Provider/ICosmosDBProvider.cs
+++ b/NCS.DSS.Outcomes/Cosmos/Provider/ICosmosDBProvider.cs
@@ -11,8 +11,8 @@ namespace NCS.DSS.Outcomes.Cosmos.Provider
         Task<bool> DoesActionPlanResourceExistAndBelongToCustomer(Guid actionPlanId, Guid interactionId, Guid customerId);
 
         Task<List<Models.Outcomes>> GetOutcomesForCustomerAsync(Guid customerId);
-        Task<string> GetOutcomesForCustomerAsyncToUpdateAsync(Guid customerId, Guid interactionsId, Guid actionPlanId, Guid outcomeId);
-        Task<Models.Outcomes> GetOutcomeForCustomerAsync(Guid customerId, Guid interactionsId, Guid actionplanId, Guid outcomeId);
+        Task<string> GetOutcomesForCustomerAsyncToUpdateAsync(Guid customerId, Guid actionPlanId, Guid outcomeId);
+        Task<Models.Outcomes> GetOutcomeForCustomerAsync(Guid customerId, Guid actionplanId, Guid outcomeId);
         Task<ItemResponse<Models.Outcomes>> CreateOutcomesAsync(Models.Outcomes outcomes);
         Task<ItemResponse<Models.Outcomes>> UpdateOutcomesAsync(string outcomeJson, Guid outcomeId);
         Task<DateTime?> GetDateAndTimeOfSessionFromSessionResource(Guid sessionId);

--- a/NCS.DSS.Outcomes/GetOutcomesByIdHttpTrigger/Service/GetOutcomesByIdHttpTriggerService.cs
+++ b/NCS.DSS.Outcomes/GetOutcomesByIdHttpTrigger/Service/GetOutcomesByIdHttpTriggerService.cs
@@ -16,7 +16,7 @@ namespace NCS.DSS.Outcomes.GetOutcomesByIdHttpTrigger.Service
         public async Task<Models.Outcomes> GetOutcomesForCustomerAsync(Guid customerId, Guid interactionId, Guid actionplanId, Guid outcomeId)
         {
             _logger.LogInformation("Attempting to get Outcome for Customer. Customer ID: {CustomerId}.", customerId);
-            var outcomes = await _cosmosDbProvider.GetOutcomeForCustomerAsync(customerId, interactionId, actionplanId, outcomeId);
+            var outcomes = await _cosmosDbProvider.GetOutcomeForCustomerAsync(customerId, actionplanId, outcomeId);
 
             if (outcomes == null)
             {

--- a/NCS.DSS.Outcomes/NCS.DSS.Outcomes.csproj
+++ b/NCS.DSS.Outcomes/NCS.DSS.Outcomes.csproj
@@ -10,9 +10,7 @@
 		<DebugSymbols>true</DebugSymbols>
 	</PropertyGroup>
 	<ItemGroup>
-		<None Include="local.settings.json">
-		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
+		<None Include="local.settings.json" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />

--- a/NCS.DSS.Outcomes/NCS.DSS.Outcomes.csproj
+++ b/NCS.DSS.Outcomes/NCS.DSS.Outcomes.csproj
@@ -10,7 +10,9 @@
 		<DebugSymbols>true</DebugSymbols>
 	</PropertyGroup>
 	<ItemGroup>
-		<None Include="local.settings.json" />
+		<None Include="local.settings.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />

--- a/NCS.DSS.Outcomes/PatchOutcomesHttpTrigger/Function/PatchOutcomesHttpTrigger.cs
+++ b/NCS.DSS.Outcomes/PatchOutcomesHttpTrigger/Function/PatchOutcomesHttpTrigger.cs
@@ -250,12 +250,12 @@ namespace NCS.DSS.Outcomes.PatchOutcomesHttpTrigger.Function
             _logger.LogInformation("Attempting to get Outcome for Customer. Customer GUID: {CustomerId}. Outcome GUID: {OutcomeGuid}. Correlation GUID: {CorrelationGuid}", customerGuid, outcomesGuid, correlationGuid);
             var outcome = await _outcomesPatchService.GetOutcomesForCustomerAsync(customerGuid, interactionGuid, actionPlanGuid, outcomesGuid);
 
-            if (outcome == null)
+            if (outcome == "null" || outcome == null)
             {
-                _logger.LogInformation("Outcome does not exist. Customer GUID: {CustomerId}. Outcome GUID: {OutcomeGuid}. Correlation GUID: {CorrelationGuid}", customerGuid, outcomesGuid, correlationGuid);
-                return new NotFoundObjectResult("Failed to PATCH Outcome. Outcome does not exist. Outcome GUID: " + outcomesGuid);
+                _logger.LogInformation("Outcome does not exist. Customer GUID: {CustomerId}. Action Plan GUID: {ActionPlanGuid}. Outcome GUID: {OutcomeGuid}. Correlation GUID: {CorrelationGuid}", customerGuid, actionPlanGuid, outcomesGuid, correlationGuid);
+                return new NotFoundObjectResult("Failed to PATCH Outcome. Outcome does not exist. Outcome GUID: " + outcomesGuid + ", Action Plan GUID: " + actionPlanGuid);
             }
-            _logger.LogInformation("Outcome exists. Customer GUID: {CustomerId}. Outcome GUID: {OutcomeGuid}. Correlation GUID: {CorrelationGuid}", customerGuid, outcomesGuid, correlationGuid);
+            _logger.LogInformation("Outcome exists. Customer GUID: {CustomerId}. Action Plan GUID: {ActionPlanGuid}. Outcome GUID: {OutcomeGuid}. Correlation GUID: {CorrelationGuid}", customerGuid, actionPlanGuid, outcomesGuid, correlationGuid);
 
 
             _logger.LogInformation("Attempting to PATCH Outcome resource.");

--- a/NCS.DSS.Outcomes/PatchOutcomesHttpTrigger/Function/PatchOutcomesHttpTrigger.cs
+++ b/NCS.DSS.Outcomes/PatchOutcomesHttpTrigger/Function/PatchOutcomesHttpTrigger.cs
@@ -248,9 +248,9 @@ namespace NCS.DSS.Outcomes.PatchOutcomesHttpTrigger.Function
 
 
             _logger.LogInformation("Attempting to get Outcome for Customer. Customer GUID: {CustomerId}. Outcome GUID: {OutcomeGuid}. Correlation GUID: {CorrelationGuid}", customerGuid, outcomesGuid, correlationGuid);
-            var outcome = await _outcomesPatchService.GetOutcomesForCustomerAsync(customerGuid, interactionGuid, actionPlanGuid, outcomesGuid);
+            var outcome = await _outcomesPatchService.GetOutcomesForCustomerAsync(customerGuid, actionPlanGuid, outcomesGuid);
 
-            if (outcome == "null" || outcome == null)
+            if (outcome == null)
             {
                 _logger.LogInformation("Outcome does not exist. Customer GUID: {CustomerId}. Action Plan GUID: {ActionPlanGuid}. Outcome GUID: {OutcomeGuid}. Correlation GUID: {CorrelationGuid}", customerGuid, actionPlanGuid, outcomesGuid, correlationGuid);
                 return new NotFoundObjectResult("Failed to PATCH Outcome. Outcome does not exist. Outcome GUID: " + outcomesGuid + ", Action Plan GUID: " + actionPlanGuid);

--- a/NCS.DSS.Outcomes/PatchOutcomesHttpTrigger/Service/IPatchOutcomesHttpTriggerService.cs
+++ b/NCS.DSS.Outcomes/PatchOutcomesHttpTrigger/Service/IPatchOutcomesHttpTriggerService.cs
@@ -8,7 +8,7 @@ namespace NCS.DSS.Outcomes.PatchOutcomesHttpTrigger.Service
             bool setOutcomeEffectiveDateToNull);
         string PatchResource(string outcomeJson, OutcomesPatch outcomesPatchPatch);
         Task<Models.Outcomes> UpdateCosmosAsync(string outcomeJson, Guid outcomeId);
-        Task<string> GetOutcomesForCustomerAsync(Guid customerId, Guid interactionsId, Guid actionPlanId, Guid outcomeId);
+        Task<string> GetOutcomesForCustomerAsync(Guid customerId, Guid actionPlanId, Guid outcomeId);
         Task SendToServiceBusQueueAsync(Models.Outcomes outcomes, Guid customerId, string reqUrl);
     }
 }

--- a/NCS.DSS.Outcomes/PatchOutcomesHttpTrigger/Service/PatchOutcomesHttpTriggerService.cs
+++ b/NCS.DSS.Outcomes/PatchOutcomesHttpTrigger/Service/PatchOutcomesHttpTriggerService.cs
@@ -60,9 +60,9 @@ namespace NCS.DSS.Outcomes.PatchOutcomesHttpTrigger.Service
             return responseStatusCode == HttpStatusCode.OK ? response.Resource : null;
         }
 
-        public async Task<string> GetOutcomesForCustomerAsync(Guid customerId, Guid interactionsId, Guid actionPlanId, Guid outcomeId)
+        public async Task<string> GetOutcomesForCustomerAsync(Guid customerId, Guid actionPlanId, Guid outcomeId)
         {
-            var outcomes = await _cosmosDbProvider.GetOutcomesForCustomerAsyncToUpdateAsync(customerId, interactionsId, actionPlanId, outcomeId);
+            var outcomes = await _cosmosDbProvider.GetOutcomesForCustomerAsyncToUpdateAsync(customerId, actionPlanId, outcomeId);
 
             return outcomes;
         }


### PR DESCRIPTION
*Added a null check before serializing the output in the GetOutcomesForCustomerAsyncToUpdateAsync method
*Removed unused parameter (interactionId) from the getOutcome methods
*Updated the returned error message to include the actionplanID